### PR TITLE
Fix the path, fix ID field bug

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -371,7 +371,7 @@ Resources:
         ProcessCallPayload:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
-            Path: /send
+            Path: /
             Method: post
             RestApiId:
               Ref: SecurityHubApi
@@ -565,4 +565,4 @@ Outputs:
 
   ApiEndpoint:
     Description: "API Gateway endpoint URL"
-    Value: !Sub "https://${SecurityHubApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${DeploymentEnvironment}/send/"
+    Value: !Sub "https://${SecurityHubApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${DeploymentEnvironment}"

--- a/transformer/app.js
+++ b/transformer/app.js
@@ -73,6 +73,10 @@ const getVulnerabilitiesFields = (prefix, artifact) => ({
   Vulnerabilities: [getVulnerabilities(prefix, artifact)],
 });
 
+const getSummarySubstring = (body) => {
+  return body.summary.length > 256 ? (body.summary).substring(0, 125) + '...' : body.summary;
+}
+
 const getCommonFields = (body, type, accountId, xrayArn) => ({
   AwsAccountId: accountId,
   Region: SECURITY_HUB_REGION,
@@ -82,7 +86,7 @@ const getCommonFields = (body, type, accountId, xrayArn) => ({
   ProductArn: xrayArn,
   SchemaVersion: '2018-10-08',
   SourceUrl: `https://${body.host_name}/ui/watchesNew/edit/${body.watch_name}?activeTab=violations`,
-  Title: `${body.summary.length > 256 ? `${(body.summary).substring(0, 251)}...` : body.summary}`,
+  Title: getSummarySubstring(body),
   UpdatedAt: body.created,
   CompanyName: 'JFrog',
   ProductFields: getProductFields(body, type),
@@ -103,7 +107,7 @@ const getFindingProviderFields = (body, type) => ({
   FindingProviderFields: getSeverityAndTypes(body, type),
 });
 
-const getIdPrefix = (body, type) => (type === 'security' && body.cve ? body.cve : body.summary);
+const getIdPrefix = (body, type) => (type === 'security' && body.cve ? body.cve : getSummarySubstring(body));
 
 function transformIssue(issue, accountId, xrayArn) {
   const type = issue.type.toLowerCase();


### PR DESCRIPTION
Fix the Vulnerability ID and Finding ID for security finding, if CVE field is missing in the Xray webhook payload.

Remove /send path to remove confusion when the app is deployed with SAM UI.